### PR TITLE
Fix dynamic config import

### DIFF
--- a/config/index.ts
+++ b/config/index.ts
@@ -14,9 +14,10 @@ import type { Config } from "./config.example";
 
 let customConfig: Partial<Config> | undefined;
 
-// Try to load custom config if it exists
+// Try to load custom config if it exists using dynamic import
 try {
-  customConfig = require("./config").config;
+  const mod = await import("./config");
+  customConfig = mod.config;
 } catch {
   // No custom config found, will use example config
 }


### PR DESCRIPTION
## Summary
- use top-level await to load `config.ts` if present

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c9ce20f50832c8d3002b308d66511