### PR TITLE
Fix SVG encoding

### DIFF
--- a/app/api/og/route.tsx
+++ b/app/api/og/route.tsx
@@ -188,7 +188,7 @@ async function fetchImageAsDataURI(
         /<svg(?=\s)([^>]*?)\s+(width|height)="[^"]*"/g,
         "<svg$1"
       );
-      return `data:image/svg+xml;base64,${btoa(svgText)}`;
+      return `data:image/svg+xml;base64,${Buffer.from(svgText).toString("base64")}`;
     } else {
       // Handle other image types (PNG, JPG, etc.)
       const imageData = await response.arrayBuffer();


### PR DESCRIPTION
## Summary
- replace `btoa` with `Buffer.from().toString("base64")` for encoding SVG images
- keep encoding consistent for OG image handlers

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c9ce360b4832cbf6e49f569a7f0c1