### PR TITLE
Fix param handling in dynamic routes

### DIFF
--- a/app/api/og/jobs/[slug]/route.tsx
+++ b/app/api/og/jobs/[slug]/route.tsx
@@ -239,8 +239,7 @@ export async function GET(
 ): Promise<ImageResponse | Response> {
   try {
     // Get the job slug and fetch job data
-    const params = await context.params;
-    const { slug } = params;
+    const { slug } = context.params;
 
     const job = await getJobBySlugMinimal(slug);
     if (!job) {

--- a/app/jobs/[slug]/page.tsx
+++ b/app/jobs/[slug]/page.tsx
@@ -34,8 +34,8 @@ export async function generateMetadata({
 }: {
   params: { slug: string };
 }): Promise<Metadata> {
-  // Get all jobs first and resolve params
-  const [allJobs, { slug }] = await Promise.all([getJobs(), params]);
+  const allJobs = await getJobs();
+  const { slug } = params;
 
   // Find the job with matching slug
   const job = allJobs.find((j) => {
@@ -168,8 +168,7 @@ export default async function JobPostPage({
 }: {
   params: { slug: string };
 }) {
-  // Await the params to resolve before using
-  const { slug } = await params;
+  const { slug } = params;
 
   const jobs = await getJobs();
   const job = jobs.find((j) => generateJobSlug(j.title, j.company) === slug);

--- a/app/jobs/language/[language]/page.tsx
+++ b/app/jobs/language/[language]/page.tsx
@@ -16,16 +16,14 @@ import { JobSearchInput } from "@/components/ui/job-search-input";
 export const revalidate = 300;
 
 interface Props {
-  params: Promise<{
+  params: {
     language: string;
-  }>;
+  };
 }
 
 // Generate metadata for SEO
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
-  // Await the entire params object first
-  const resolvedParams = await params;
-  const languageCode = resolvedParams.language.toLowerCase();
+  const languageCode = params.language.toLowerCase();
 
   // Check if valid language code
   if (!LANGUAGE_CODES.includes(languageCode as LanguageCode)) {
@@ -46,9 +44,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
 export default async function LanguagePage({ params }: Props) {
   const jobs = await getJobs();
-  // Await the entire params object first
-  const resolvedParams = await params;
-  const languageCode = resolvedParams.language.toLowerCase();
+  const languageCode = params.language.toLowerCase();
 
   // Check if valid language code
   if (!LANGUAGE_CODES.includes(languageCode as LanguageCode)) {

--- a/app/jobs/level/[level]/page.tsx
+++ b/app/jobs/level/[level]/page.tsx
@@ -12,9 +12,9 @@ import { JobSearchInput } from "@/components/ui/job-search-input";
 export const revalidate = 300;
 
 interface Props {
-  params: Promise<{
+  params: {
     level: string;
-  }>;
+  };
 }
 
 /**
@@ -30,9 +30,7 @@ function getCareerLevelFromSlug(slug: string): CareerLevel | null {
 
 // Generate metadata for SEO
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
-  // Await the entire params object first
-  const resolvedParams = await params;
-  const levelSlug = decodeURIComponent(resolvedParams.level).toLowerCase();
+  const levelSlug = decodeURIComponent(params.level).toLowerCase();
   const careerLevel = getCareerLevelFromSlug(levelSlug);
 
   if (!careerLevel || careerLevel === "NotSpecified") {
@@ -53,9 +51,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
 export default async function CareerLevelPage({ params }: Props) {
   const jobs = await getJobs();
-  // Await the entire params object first
-  const resolvedParams = await params;
-  const levelSlug = decodeURIComponent(resolvedParams.level).toLowerCase();
+  const levelSlug = decodeURIComponent(params.level).toLowerCase();
   const careerLevel = getCareerLevelFromSlug(levelSlug);
 
   if (!careerLevel || careerLevel === "NotSpecified") {

--- a/app/jobs/type/[type]/page.tsx
+++ b/app/jobs/type/[type]/page.tsx
@@ -16,9 +16,9 @@ import { JobSearchInput } from "@/components/ui/job-search-input";
 export const revalidate = 300;
 
 interface Props {
-  params: Promise<{
+  params: {
     type: string;
-  }>;
+  };
 }
 
 /**
@@ -34,9 +34,7 @@ function getJobTypeFromSlug(slug: string): JobType | null {
 
 // Generate metadata for SEO
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
-  // Await the entire params object first
-  const resolvedParams = await params;
-  const typeSlug = decodeURIComponent(resolvedParams.type).toLowerCase();
+  const typeSlug = decodeURIComponent(params.type).toLowerCase();
   const jobType = getJobTypeFromSlug(typeSlug);
 
   if (!jobType) {
@@ -58,9 +56,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
 export default async function JobTypePage({ params }: Props) {
   const jobs = await getJobs();
-  // Await the entire params object first
-  const resolvedParams = await params;
-  const typeSlug = decodeURIComponent(resolvedParams.type).toLowerCase();
+  const typeSlug = decodeURIComponent(params.type).toLowerCase();
   const jobType = getJobTypeFromSlug(typeSlug);
 
   if (!jobType) {


### PR DESCRIPTION
## Summary
- update dynamic job pages to use direct params
- clean up slug OG route

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c9ce42a84832cbd04aef7b57f9cb7